### PR TITLE
adds objbase.h header include

### DIFF
--- a/WLANOptimizer.cpp
+++ b/WLANOptimizer.cpp
@@ -44,6 +44,7 @@ static std::mutex APILock;
 #undef _WIN32_WINNT
 #define _WIN32_WINNT _WIN32_WINNT_WIN7 /* must be defined for wlanapi.h */
 #include <wlanapi.h>
+#include <objbase.h>
 #pragma comment(lib, "wlanapi")
 #pragma comment(lib, "ole32")
 


### PR DESCRIPTION
i'm attempting to compile from visualstudio community edition on windows 10.

i was getting a lot of build errors and this include fixed the majority of undefined types (`DWORD`, `HANDLE`, etc)

i'm not a windows developer, though. so i'm not sure if this was the right way to fix my build, but it works now 🤷‍♂️ 